### PR TITLE
build: expo 빌드용 cd 스크립트 작성

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,3 +66,9 @@ jobs:
 
       # - name: reflect testflight
       #   run: eas submit -p ios --latest --profile local --non-interactive
+
+      - name: Discord Webhook Action
+        uses: tsickert/discord-webhook@v5.3.0
+        with:
+          webhook-url: ${{ secrets.WEBHOOK_URL }}
+          content: "따끈따끈한 새 빌드가 완료됐다네~"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: build expo by eas
+name: build expo via eas
 
 on:
   push:
@@ -16,6 +16,7 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v3
 
+      # 필요 json 파일들 세팅
       - name: create firebase.json
         uses: jsdaniell/create-json@1.1.2
         with:
@@ -40,6 +41,7 @@ jobs:
           name: "eas.json"
           json: ${{ secrets.EAS_JSON }}
 
+      # 노드, 패키지 매니저, 캐시 설정
       - name: setup node with cache
         uses: actions/setup-node@v3
         with:
@@ -47,15 +49,18 @@ jobs:
           cache: npm
           cache-dependency-path: ./package-lock.json
 
+      # eas 설정
       - name: setup eas
         uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
+      # npm 의존성 설치
       - name: install dependencies
         run: npm install
 
+      # eas를 통해 새로 빌드 후 반영
       - name: publish update
         run: eas update --profile local --non-interactive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
       # - name: reflect testflight
       #   run: eas submit -p ios --latest --profile local --non-interactive
 
+      # 디스코드 웹훅 알림 전송
       - name: Discord Webhook Action
         uses: tsickert/discord-webhook@v5.3.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,22 @@
-name: build expo
+name: build expo by eas
 
 on:
   push:
-    branches: [ feature/home ]
+    branches: [ release ]
+
+  pull_request:
+    branches: [ release ]
+
 
 jobs:
   update:
-    name: EAS Update
+    name: build expo file via eas
     runs-on: ubuntu-latest
     steps:
-
       - name: checkout repository
         uses: actions/checkout@v3
 
-      - name: create bookbla-2024-firebase-adminsdk.json
+      - name: create firebase.json
         uses: jsdaniell/create-json@1.1.2
         with:
           name: "bookbla-2024-firebase-adminsdk-qfspu-1dcca92597.json"
@@ -37,14 +40,14 @@ jobs:
           name: "eas.json"
           json: ${{ secrets.EAS_JSON }}
 
-      - name: setup Node
+      - name: setup node with cache
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
           cache: npm
           cache-dependency-path: ./package-lock.json
 
-      - name: setup EAS
+      - name: setup eas
         uses: expo/expo-github-action@v8
         with:
           eas-version: latest
@@ -54,7 +57,7 @@ jobs:
         run: npm install
 
       - name: publish update
-        run: eas build -p all --profile local --non-interactive
+        run: eas update --profile local --non-interactive
 
-      - name: reflect testflight
-        run: eas submit -p ios --latest --profile local --non-interactive
+      # - name: reflect testflight
+      #   run: eas submit -p ios --latest --profile local --non-interactive


### PR DESCRIPTION
### 스크립트 내용
- release 브랜치에 PR이나 푸쉬 이벤트 발생시 자동으로 eas 통해 빌드하도록 해놨어요

### 자잘한 반영사항
- .gitignore 파일 내 .json 으로 끝나는 친구들을 없앴습니다
eas가 빌드할 때 .gitignore파일을 한번 훑더라구요. 빌드하려면 저 파일들 필요해서 .gitignore 파일 내에서 없애줬어요
- 위 .json 파일들은 도플러를 통해 관리하고 있습니다. 깃허브 레포의 시크릿과 동기화시켜놨어요

### 브랜치 전략 변경
expo는 월 30회 무료 빌드가 가능합니다

매번 develop 브랜치에 머지될 때마다, 새로 빌드하도록 설정한다면
기한이 빠듯하다는 등의 이유로 작업량이 많아지면, 무료 빌드 횟수를 초과할 수 있다고 생각했습니다
그래서 성진님과 , develop -> release -> main(production) 의 형태로 브랜치 전략을 가져가기로 하였슴니당

기존 코드레벨의 작업은 develop으로 계속 이어서 할 수 있도록요!

참고 자료
![image](https://github.com/BookBLA/barista/assets/73161212/85c3f9e9-965d-49a7-b64c-ffd9570739d9)
